### PR TITLE
correct version handling, simplify

### DIFF
--- a/superdirt/tools/quarkinstall.sc
+++ b/superdirt/tools/quarkinstall.sc
@@ -1,7 +1,5 @@
-Quarks.install("https://github.com/supercollider-quarks/Vowel.git");
-Quarks.install("https://github.com/musikinformatik/SuperDirt.git");
-"** Downloading samples ** - please be patient, this may take a while.".postln;
-Quarks.install("https://github.com/musikinformatik/Dirt-Samples.git");
+"** Downloading SuperDirt inc. samples ** - please be patient, this may take a while.".postln;
+Quarks.install("SuperDirt", "v1.7.3");
 "SuperDirt installation complete!".postln;
 thisProcess.shutdown;
 0.exit;


### PR DESCRIPTION
as per telephon's discussion in https://github.com/tidalcycles/tidal-chocolatey/issues/11

We shouldn't be pulling the `dev` branch of SuperDirt

Using `"SuperDirt"` as the target also automatically installs the Vowel and Dirt-Samples quarks (simpler!)